### PR TITLE
chore: create issue templates from github settings (#1)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,43 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: 'bug:'
+labels: bug
+assignees: ''
+
+---
+
+## Prerequisites
+- [x] No other issue talks about this.
+- [ ] Can you reproduce the problem?
+- [ ] Are you reporting to the correct repository?
+- [ ] Is the bug present on the latest release?
+
+## Describe the bug
+[A clear and concise description of what the bug is.]
+
+## Steps to Reproduce
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+## Expected behavior
+
+[What you expected to happen]
+
+## Actual behavior
+
+[What actually happened]
+
+## Screenshots
+If applicable, add screenshots to help explain your problem.
+
+## Environment
+ - Version of `i18lint`: [execute `i18lint --version` to get info]
+ - Version of `npm`: [enter npm version]
+ - Version of `node`: [enter node version]
+ - Operating system: [enter os name and version]
+
+## Additional context
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,26 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: 'feat: '
+labels: enhancement
+assignees: ''
+
+---
+
+## Is your feature request related to a problem? Please describe.
+[A clear and concise description of what the problem is. Ex. I'm always frustrated when ...]
+
+## Describe the solution you'd like
+[A clear and concise description of what you want to happen.]
+
+## Describe alternatives you've considered
+[A clear and concise description of any alternative solutions or features you've considered.]
+
+## Mockups
+
+[Imagine this feature is working. Provide mockups of this feature (these can be textual descriptions, images, etc).]
+
+## Checklist
+
+- [x] I've checked and no other issue talks about this.
+- [ ] I have a solution for this. (I am willing to submit a PR solving this.) 😎

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,20 @@
+---
+name: Question
+about: Ask question about the project
+title: 'question: '
+labels: question
+assignees: ''
+
+---
+
+## Description
+
+[Enter your question here]
+
+## Appendix
+
+[Additional content, if applies]
+
+## Checklist
+
+- [x] I've checked and no other issue talks about this.


### PR DESCRIPTION
## Description
<!-- A clear and concise description what these changes do. -->
This PR creates the issue templates from the github settings in hope of enabling the issue templates.

## Checklist
- [x] the pull request targets the *default* branch of the repository (`develop`)
- [ ] documentation added or updated (if applies)
- [ ] I have run the project locally and verified that there are no errors

By sending this PR to review I state it meets the following criteria:

- pull request title describes what this PR does (not a vague title like `Update index.md`)
- pull request follows our [contributing guidelines](../CONTRIBUTING.md) on opening PRs
- this branch is up-to-date with latest changes from target branch

## Issues
<!-- If there is no issue being resolved, open one before creating this pull request. -->
- #1 