### PR TITLE
ci: rename job names and run release on master only (#11)

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,11 +1,16 @@
-name: Lint Commit Messages
+name: Check commit messages
 on: [pull_request]
 
 jobs:
   commitlint:
+    name: Check commit messages
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout branch
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: wagoid/commitlint-github-action@v5
+
+      - name: Commit lint
+        uses: wagoid/commitlint-github-action@v5

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Check out Git repository
+      - name: Checkout branch
         uses: actions/checkout@v2
 
       - name: Get changed files
@@ -17,16 +17,16 @@ jobs:
           files: |
             src/**/*.ts
 
-      - name: Set up Node.js
+      - name: Set up Node
         if: steps.changed-files.outputs.any_changed == 'true'
         uses: actions/setup-node@v1
         with:
           node-version: 16
 
-      - name: Install Node.js dependencies
+      - name: Install dependencies
         if: steps.changed-files.outputs.any_changed == 'true'
         run: npm ci
 
-      - name: Lint
+      - name: Check ESLint
         if: steps.changed-files.outputs.any_changed == 'true'
         run: npm run lint:ci -- ${{ steps.changed-files.outputs.all_changed_files }}

--- a/.github/workflows/pretty.yml
+++ b/.github/workflows/pretty.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Check out Git repository
+      - name: Checkout branch
         uses: actions/checkout@v2
 
       - name: Get changed files
@@ -18,16 +18,16 @@ jobs:
             *.md
             src/**/*.ts
 
-      - name: Set up Node.js
+      - name: Set up Node
         if: steps.changed-files.outputs.any_changed == 'true'
         uses: actions/setup-node@v1
         with:
           node-version: 16
 
-      - name: Install Node.js dependencies
+      - name: Install dependencies
         if: steps.changed-files.outputs.any_changed == 'true'
         run: npm ci
 
-      - name: Lint
+      - name: Check prettier
         if: steps.changed-files.outputs.any_changed == 'true'
         run: npm run prettier:ci -- ${{ steps.changed-files.outputs.all_changed_files }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,13 +1,16 @@
+name: Release
+
 on:
   push:
     branches:
-      - develop
-name: release-please
+      - master
+
 jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v3
+      - name: Run Release Please
+        uses: google-github-actions/release-please-action@v3
         id: release
         with:
           release-type: node
@@ -16,19 +19,23 @@ jobs:
           changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false}]'
           default-branch: master
 
-      # The logic below handles the npm publication:
-      - uses: actions/checkout@v2
-        # these if statements ensure that a publication only occurs when
-        # a new release is created:
+      - name: Checkout branch
         if: ${{ steps.release.outputs.release_created }}
-      - uses: actions/setup-node@v1
+        uses: actions/checkout@v2
+
+      - name: Setup Node
+        if: ${{ steps.release.outputs.release_created }}
+        uses: actions/setup-node@v1
         with:
           node-version: 16
           registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
         if: ${{ steps.release.outputs.release_created }}
-      - run: npm ci
+        run: npm ci
+
+      - name: Publish package to npm
         if: ${{ steps.release.outputs.release_created }}
-      - run: npm publish
+        run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-        if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
## Description

<!-- A clear and concise description what these changes do. -->

This PR renames github action job names in general and makes release job run on only master push.

## Checklist

- [x] the pull request targets the _default_ branch of the repository (`develop`)
- [ ] documentation added or updated (if applies)
- [ ] I have run the project locally and verified that there are no errors

By sending this PR to review I state it meets the following criteria:

- pull request title describes what this PR does (not a vague title like `Update index.md`)
- pull request follows our [contributing guidelines](../CONTRIBUTING.md) on opening PRs
- this branch is up-to-date with latest changes from target branch

## Issues

<!-- If there is no issue being resolved, open one before creating this pull request. -->

- #11 
